### PR TITLE
Fix typo in playground/readme.md

### DIFF
--- a/playground/readme.md
+++ b/playground/readme.md
@@ -2,7 +2,7 @@
 
 This folder is a playground to test git-bob on a repository. 
 
-This file contains a tpyo. Let's see what is going to happen with it.
+This file contains a typo. Let's see what is going to happen with it.
 
 May it stay here forever? Or does an AI find it and fix it?
 
@@ -10,5 +10,3 @@ Time will tell.
 
 Best, 
 Robert
-
-


### PR DESCRIPTION
This pull request fixes a typo in the file playground/readme.md. Closes #12.

git-bob comment