### PR TITLE
Prevent endless loop when reporting an error in the error reporting routine

### DIFF
--- a/src/git_bob/_terminal.py
+++ b/src/git_bob/_terminal.py
@@ -73,8 +73,14 @@ def command_line_interface():
         if not check_access_and_ask_for_approval(user, repository, issue):
             sys.exit(1)
 
-    # add reaction to issue to show that we're working on it
-    add_reaction_to_last_comment_in_issue(repository, issue, "+1")
+    # add reaction to issue to show that we're working on it; if this fails, we do not fail due to the error, because it's not critical
+    ErrorReporting.status = False
+    try:
+        add_reaction_to_last_comment_in_issue(repository, issue, "+1")
+    except:
+        print("Error: Could not add reaction to issue.")
+        pass
+    ErrorReporting.status = True
 
 
     # execute the task

--- a/src/git_bob/_utilities.py
+++ b/src/git_bob/_utilities.py
@@ -97,7 +97,11 @@ This is how far I came:
 
 [More Details...](https://github.com/{repository}/actions/runs/{run_id})
 """
+    before = ErrorReporting.status
+    ErrorReporting.status = False
     add_comment_to_issue(repository, issue, complete_error_message)
+    ErrorReporting.status = before
+
 
 @curry
 def catch_error(func):


### PR DESCRIPTION
git-bob review