### PR TITLE
Add a markdown cell with an 'add_numbers' exercise to python_basics.ipynb notebook.

### DIFF
--- a/playground/python_basics.ipynb
+++ b/playground/python_basics.ipynb
@@ -18,18 +18,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "5\n",
-      "Hello\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# This is a variable\n",
     "x = 5\n",
@@ -48,17 +39,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello Alice\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# This is a function\n",
     "def greet(name):\n",
@@ -77,25 +60,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0\n",
-      "1\n",
-      "2\n",
-      "3\n",
-      "4\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# This is a loop\n",
     "for i in range(5):\n",
     "    print(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercise\n",
+    "Write a function `add_numbers` that takes two numbers as input and returns their sum. Then, call this function with different pairs of numbers to test it."
    ]
   }
  ],


### PR DESCRIPTION
<sup>This message was generated by [git-bob](https://github.com/haesleinhuepf/git-bob) (version: 0.2.1, model: gpt-4o-2024-08-06), an experimental AI-based assistant. It can make mistakes and has [limitations](https://github.com/haesleinhuepf/git-bob?tab=readme-ov-file#limitations). Check its messages carefully.</sup>

Added a markdown cell to the `playground/python_basics.ipynb` notebook with an exercise to prompt users to write a function named `add_numbers`. This exercise encourages practicing the implementation of functions by taking two numbers as input and returning their sum. Adjustments also included removing previous code execution outputs, ensuring the notebook is in a consistent initial state for users.

closes #150