### PR TITLE
Add practice exercise to python_basics notebook for concept reinforcement.

### DIFF
--- a/playground/python_basics.ipynb
+++ b/playground/python_basics.ipynb
@@ -97,6 +97,14 @@
     "for i in range(5):\n",
     "    print(i)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Practice Exercise\n",
+    "Try creating a list of numbers from 1 to 10 and print each number using a loop."
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
<sup>This message was generated by [git-bob](https://github.com/haesleinhuepf/git-bob) (version: 0.2.1, model: gpt-4o-2024-08-06), an experimental AI-based assistant. It can make mistakes and has [limitations](https://github.com/haesleinhuepf/git-bob?tab=readme-ov-file#limitations). Check its messages carefully.</sup>

Added a new markdown cell at the end of the "playground/python_basics.ipynb" Jupyter notebook to include a practice exercise. The exercise instructs students to create a list of numbers from 1 to 10 and print each number using a loop, allowing them to practice the concepts they have learned in the notebook.

closes #150