### PR TITLE
enable-reading-file-before-action

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,11 +56,13 @@ git-bob solve
 Here's the recommended workflow for using git-bob:
 
 1. Create an issue describing the problem or task.
-2. Comment on the issue with `git-bob solve` to trigger git-bob.
-3. Wait for git-bob to create a pull request (PR) addressing the issue.
-4. Review the PR and comment on the issue if changes are needed.
-5. Wait for git-bob to create a second PR with the requested changes.
-6. Repeat steps 4-5 as necessary until the issue is resolved satisfactorily.
+2. Comment on the issue with `git-bob comment` to trigger git-bob making a plan.
+3. Respond to git-bob with any clarifications or additional information it requests.
+4. Comment on the issue with `git-bob solve` to trigger git-bob.
+5. Wait for git-bob to create a pull request (PR) addressing the issue.
+6. Review the PR and comment on the issue if changes are needed.
+7. Wait for git-bob to create a second PR with the requested changes.
+8. Repeat steps 3-5 as necessary until the issue is resolved satisfactorily.
 
 ## Use-case examples
 

--- a/src/git_bob/_terminal.py
+++ b/src/git_bob/_terminal.py
@@ -58,7 +58,9 @@ def command_line_interface():
     # handle aliases
     text = text.replace("git-bob respond", "git-bob comment")
     text = text.replace("git-bob review", "git-bob comment")
-    
+    text = text.replace("git-bob think about", "git-bob comment")
+    text = text.replace("git-bob implement", "git-bob solve")
+
     if running_in_github_ci:
         if not ("git-bob comment" in text or "git-bob solve" in text):
             print("They didn't speak to me. I show myself out.")
@@ -79,6 +81,8 @@ def command_line_interface():
         solve_github_issue(repository, issue, llm_name, prompt)
     elif task == "comment-on-issue" and ("git-bob comment" in text or not running_in_github_ci):
         comment_on_issue(repository, issue, prompt)
+    else:
+        raise NotImplementedError("Unknown task. I show myself out.")
 
     print("Done. Summary:")
     print("* " + "\n* ".join(Log().get()))

--- a/src/git_bob/_utilities.py
+++ b/src/git_bob/_utilities.py
@@ -80,13 +80,6 @@ def quick_first_response():
     # add reaction to issue
     add_reaction_to_last_comment_in_issue(repository, issue, "+1")
 
-    message = f"""
-{ai_remark}
-
-I'm on it! [Read Details...](https://github.com/{repository}/actions/runs/{run_id})
-"""
-    add_comment_to_issue(repository, issue, message)
-
 
 def split_content_and_summary(text):
     """
@@ -137,3 +130,23 @@ def erase_outputs_of_code_cells(file_content):
             cell['execution_count'] = None
     file_content = json.dumps(notebook, indent=1)
     return file_content
+
+
+def text_to_json(text):
+    """Converts a string, e.g. a response from an LLM, to a valid JSON object."""
+    import json
+    if "[" in text:
+        text = "[" +  text.split("[")[1]
+    if "]" in text:
+        text = text.split("]")[0] + "]"
+
+    print("JSON?:", text)
+
+    return json.loads(text)
+
+
+def modify_discussion(discussion):
+    import re
+    discussion = discussion.replace("\n#", "\n###")
+    return re.sub(r'<sup>.*?</sup>', '', discussion)
+


### PR DESCRIPTION
With this PR, we are changing the default-workflow by internally adding additional steps: inspection of relevant files and planning actions. This allows us to commet on git-bob's ideas before asking it to implement them.