### PR TITLE
Added image segmentation example to Jupyter notebook using OpenCV for microscopy images.

### DIFF
--- a/playground/python_basics.ipynb
+++ b/playground/python_basics.ipynb
@@ -105,6 +105,50 @@
     "## Exercise\n",
     "Write a function `sum_up_to(n)` that returns the sum of all integers from 1 to `n`."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Image Segmentation in Python\n",
+    "Below is an example using OpenCV to segment the nuclei in the blue channel of an image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cv2\n",
+    "import numpy as np\n",
+    "\n",
+    "# Load the image\n",
+    "# Assuming the image is available at the specified path\n",
+    "image = cv2.imread('hela-cells-8bit.png')\n",
+    "\n",
+    "# Split the channels and get the blue channel\n",
+    "_, _, blue_channel = cv2.split(image)\n",
+    "\n",
+    "# Apply Gaussian Blur to smooth the image\n",
+    "blurred = cv2.GaussianBlur(blue_channel, (5, 5), 0)\n",
+    "\n",
+    "# Use Otsu's thresholding to binarize the image\n",
+    "_, binary = cv2.threshold(blurred, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)\n",
+    "\n",
+    "# Find contours in the binary image\n",
+    "contours, _ = cv2.findContours(binary, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)\n",
+    "\n",
+    "# Draw contours on the original image for visualization\n",
+    "for contour in contours:\n",
+    "    cv2.drawContours(image, [contour], -1, (0, 255, 0), 2)\n",
+    "\n",
+    "# Save or display the segmented image\n",
+    "cv2.imwrite('segmented_image.png', image)\n",
+    "# cv2.imshow('Segmented Image', image)\n",
+    "# cv2.waitKey(0)\n",
+    "# cv2.destroyAllWindows()"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
<sup>This message was generated by [git-bob](https://github.com/haesleinhuepf/git-bob) (version: 0.2.8, model: gpt-4o-2024-08-06), an experimental AI-based assistant. It can make mistakes and has [limitations](https://github.com/haesleinhuepf/git-bob?tab=readme-ov-file#limitations). Check its messages carefully.</sup>

Added a section in the Jupyter notebook on image segmentation using OpenCV, specifically targeting the blue channel of a microscopy image to identify and segment cell nuclei. The example provided demonstrates loading an image, extracting the blue channel, applying a Gaussian blur for noise reduction, using Otsu's thresholding for binarization, finding contours to represent segmented nuclei, and drawing these contours on the original image. Additionally, addressed issue #263 by providing code and guidance for segmenting objects in the blue channel. Encountered an error related to a missing function 'download_to_repository' during the image download process.

closes #263